### PR TITLE
Fix missing closure in finding drive widget

### DIFF
--- a/lib/finding_drive8/finding_drive8_widget.dart
+++ b/lib/finding_drive8/finding_drive8_widget.dart
@@ -1364,7 +1364,7 @@ class _FindingDrive8WidgetState extends State<FindingDrive8Widget>
                       ),
                     ],
                   );
-                ],
+                },
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- close the StreamBuilder builder in `finding_drive8_widget.dart` to fix syntax errors seen during Flutter builds

## Testing
- flutter analyze (fails: flutter command not found in environment)

------
https://chatgpt.com/codex/tasks/task_b_68d7369195348331be490b3fd07c26a4