### PR TITLE
Fix overlay StreamBuilder syntax error

### DIFF
--- a/lib/finding_drive8/finding_drive8_widget.dart
+++ b/lib/finding_drive8/finding_drive8_widget.dart
@@ -1221,7 +1221,7 @@ class _FindingDrive8WidgetState extends State<FindingDrive8Widget>
                     viewingLabel,
                     availabilityLabel,
                   );
-                ],
+                },
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- replace an incorrect closing bracket in the overlay StreamBuilder
- ensure the builder callback closes properly to restore Dart syntax

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d847096e288331a28ffdd74d63cceb